### PR TITLE
Handle sqlalchemy exceptions gracefully.

### DIFF
--- a/fireflower/core.py
+++ b/fireflower/core.py
@@ -38,14 +38,13 @@ def luigi_run_with_sentry(func):
         try:
             return func(self, *args, **kwargs)
         except Exception:
-            type_, value, traceback_ = sys.exc_info()
             if FireflowerStateManager.sentry.client:
                 extra = {
                     'task_args': self.param_args,
                     'task_kwargs': self.param_kwargs,
                 }
                 FireflowerStateManager.sentry.captureException(extra=extra)
-            raise type_(value).with_traceback(traceback_)
+            raise
         finally:
             FireflowerStateManager.sentry.client.context.clear()
     return wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ nose==1.3.7
 testfixtures==4.1.2
 moto==0.4.2
 httpretty==0.8.10
+raven==5.10.2

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -1,0 +1,35 @@
+from collections import namedtuple
+from unittest import TestCase
+
+from raven.base import DummyClient
+from raven.contrib.flask import Sentry
+from sqlalchemy.exc import DBAPIError
+
+from fireflower.core import FireflowerStateManager, luigi_run_with_sentry
+import sys
+import traceback
+
+FakeContext = namedtuple('FakeContext', ['clear'])
+
+
+class CoreTests(TestCase):
+    def test_sqlalchemy_exc_handling(self):
+        sentry = Sentry(client=DummyClient(), client_cls=DummyClient)
+        FireflowerStateManager.register_sentry(sentry)
+        @luigi_run_with_sentry
+        def error_raiser(self):
+            inner_func()
+
+        def inner_func():
+            raise DBAPIError('test error', {}, None)
+
+        class FakeTask:
+            def __init__(self):
+                self.param_args = []
+                self.param_kwargs = {}
+        try:
+            error_raiser(FakeTask())
+        except:
+            type_, _, tb = sys.exc_info()
+            self.assertEqual(type_, DBAPIError)
+            self.assertEqual(traceback.extract_tb(tb)[3].name, 'inner_func')


### PR DESCRIPTION
@b11z 

Before this pull request, re-raising sqlalchemy exceptions caused an error due to missing positional arguments. This error distractingly appeared in Sentry alerts. It seems like we were being unnecessarily clever with re-raising the error. Perhaps this was due to Python 2 exception-handling not being as good as in Python 3. 

I've also written a test to check that the exception is handled as expected.