### PR TITLE
logger.new to avoid leaking logger.bind; also log task_uuid

### DIFF
--- a/fireflower/core.py
+++ b/fireflower/core.py
@@ -63,6 +63,8 @@ def luigi_run_wrapper(func):
     def wrapper(self, *args, **kwargs):
         task_uuid = str(uuid.uuid4())
         try:
+            logger.new()  # Clear everything from previous .bind() calls
+            logger.bind(task_uuid=task_uuid)
             with FireflowerStateManager.bind_structlog(
                     uuid=task_uuid,
                     task_family=self.task_family):


### PR DESCRIPTION
- For https://opendoor.phacility.com/T114

Test plan:
- `logger.new`: Didn't slow down to identify existing events with leaky
  logger.bind data, so no test plan here
- `task_uuid`: Every log event should have a `task_uuid`