### PR TITLE
Register datadog, so datadog metrics can be flushed

### DIFF
--- a/fireflower/core.py
+++ b/fireflower/core.py
@@ -28,6 +28,7 @@ class FireflowerStateManager(object):
     session = None
     structlog_threadlocal = False
     sentry = None
+    dogstatsd = None
 
     @classmethod
     def register_sqlalchemy_session(cls, session):
@@ -36,6 +37,10 @@ class FireflowerStateManager(object):
     @classmethod
     def register_sentry(cls, sentry):
         cls.sentry = sentry
+
+    @classmethod
+    def register_datadog_dogstatsd(cls, dogstatsd):
+        cls.dogstatsd = dogstatsd
 
     @classmethod
     def register_structlog_threadlocal(cls):
@@ -79,11 +84,13 @@ def luigi_run_wrapper(func):
                     'task_kwargs': self.param_kwargs,
                 }
                 FireflowerStateManager.sentry.captureException(extra=extra)
+                FireflowerStateManager.dogstatsd.close_buffer()
             raise
         finally:
             if (FireflowerStateManager.sentry and
                     FireflowerStateManager.sentry.client):
                 FireflowerStateManager.sentry.client.context.clear()
+                FireflowerStateManager.dogstatsd.close_buffer()
     return wrapper
 
 


### PR DESCRIPTION
This PR is in conjunction with https://github.com/opendoor-labs/signals/pull/3265 and https://github.com/opendoor-labs/dwellings/pull/1662, this is so the FireflowerStateManager has registered the datadog client and can flush the datadog metric on completion (both failure and correct completion).

These set of PRs will also replace https://github.com/opendoor-labs/signals/pull/3230 and https://github.com/opendoor-labs/od_util/pull/104, since there is no need to change the buffer size like this anymore. 

I will soon create a PR to change the buffer size to something like 10, instead of 50 however.